### PR TITLE
Update webhook to use v1 api

### DIFF
--- a/pod-identity-webhook/mutatingwebhook.yaml
+++ b/pod-identity-webhook/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
@@ -17,3 +17,7 @@ webhooks:
     apiGroups: [""]
     apiVersions: ["v1"]
     resources: ["pods"]
+  sideEffects: None
+  admissionReviewVersions: 
+    - v1
+    - v1beta1


### PR DESCRIPTION
closes #2 

Likely needs to hold for https://github.com/aws/amazon-eks-pod-identity-webhook/pull/115